### PR TITLE
Smaato: Add UserSyncs

### DIFF
--- a/modules/smaatoBidAdapter.js
+++ b/modules/smaatoBidAdapter.js
@@ -19,10 +19,11 @@ import {ortbConverter} from '../libraries/ortbConverter/converter.js';
 
 const BIDDER_CODE = 'smaato';
 const SMAATO_ENDPOINT = 'https://prebid.ad.smaato.net/oapi/prebid';
-const SMAATO_CLIENT = 'prebid_js_$prebid.version$_3.1'
+const SMAATO_CLIENT = 'prebid_js_$prebid.version$_3.2'
 const TTL = 300;
 const CURRENCY = 'USD';
 const SUPPORTED_MEDIA_TYPES = [BANNER, VIDEO, NATIVE];
+const SYNC_URL = 'https://s.ad.smaato.net/c/?adExInit=p'
 
 export const spec = {
   code: BIDDER_CODE,
@@ -196,6 +197,22 @@ export const spec = {
    * @return {UserSync[]} The user syncs which should be dropped.
    */
   getUserSyncs: (syncOptions, serverResponses, gdprConsent, uspConsent) => {
+    if (syncOptions && syncOptions.pixelEnabled) {
+      let gdprParams = '';
+      if (gdprConsent && gdprConsent.consentString) {
+        if (typeof gdprConsent.gdprApplies === 'boolean') {
+          gdprParams = `&gdpr=${Number(gdprConsent.gdprApplies)}&gdpr_consent=${gdprConsent.consentString}`;
+        } else {
+          gdprParams = `&gdpr_consent=${gdprConsent.consentString}`;
+        }
+      }
+
+      return [{
+        type: 'image',
+        url: SYNC_URL + gdprParams
+      }];
+    }
+
     return [];
   }
 }

--- a/test/spec/modules/smaatoBidAdapter_spec.js
+++ b/test/spec/modules/smaatoBidAdapter_spec.js
@@ -12,6 +12,8 @@ import 'modules/consentManagementTcf.js';
 import 'modules/consentManagementUsp.js';
 import 'modules/schain.js';
 
+const SYNC_URL = 'https://s.ad.smaato.net/c/?adExInit=p'
+
 const ADTYPE_IMG = 'Img';
 const ADTYPE_VIDEO = 'Video';
 const ADTYPE_NATIVE = 'Native';
@@ -1667,8 +1669,41 @@ describe('smaatoBidAdapterTest', () => {
   });
 
   describe('getUserSyncs', () => {
-    it('returns no pixels', () => {
+    it('when pixelEnabled false then returns no pixels', () => {
       expect(spec.getUserSyncs()).to.be.empty
+    })
+
+    it('when pixelEnabled true then returns pixel', () => {
+      expect(spec.getUserSyncs({pixelEnabled: true}, null, null, null)).to.deep.equal(
+        [
+          {
+            type: 'image',
+            url: SYNC_URL
+          }
+        ]
+      )
+    })
+
+    it('when pixelEnabled true and gdprConsent then returns pixel with gdpr params', () => {
+      expect(spec.getUserSyncs({pixelEnabled: true}, null, {gdprApplies: true, consentString: CONSENT_STRING}, null)).to.deep.equal(
+        [
+          {
+            type: 'image',
+            url: `${SYNC_URL}&gdpr=1&gdpr_consent=${CONSENT_STRING}`
+          }
+        ]
+      )
+    })
+
+    it('when pixelEnabled true and gdprConsent without gdpr then returns pixel with gdpr_consent', () => {
+      expect(spec.getUserSyncs({pixelEnabled: true}, null, {consentString: CONSENT_STRING}, null), null).to.deep.equal(
+        [
+          {
+            type: 'image',
+            url: `${SYNC_URL}&gdpr_consent=${CONSENT_STRING}`
+          }
+        ]
+      )
     })
   })
 });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->

- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 

## Description of change
<!-- Describe the change proposed in this pull request -->
Adding implementation of getUserSyncs() for Smaato adapter

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
